### PR TITLE
calculate maximum image size required, apply PSR-2 coding standard

### DIFF
--- a/Config/app.config.php
+++ b/Config/app.config.php
@@ -134,7 +134,6 @@ Configure::write('app.categoryImageSizes', array(
 Configure::write('app.sliderImageSizes', array(
     '905' => array('suffix' => '-slider') // detail AND lightbox
 ));
-Configure::write('app.tmpUploadFileSize', 800);
 Configure::write('app.tmpUploadImagesDir', Configure::read('app.tmpWwwDir').DS.'images');
 
 Configure::write('app.langId', 1);

--- a/Plugin/Admin/Controller/ToolsController.php
+++ b/Plugin/Admin/Controller/ToolsController.php
@@ -39,8 +39,7 @@ class ToolsController extends AdminAppController
         $filename = StringComponent::createRandomString(10) . '.' . $extension;
         $filenameWithPath = Configure::read('app.tmpUploadImagesDir') . DS . $filename;
         $thumb = PhpThumbFactory::create($this->params['form']['upload']['tmp_name']);
-        $this->calculateTmpUploadFileSize();
-        $thumb->resize(Configure::read('app.tmpUploadFileSize'));
+        $thumb->resize($this->getMaxTmpUploadFileSize());
         $thumb->save(WWW_ROOT . $filenameWithPath);
 
         die(json_encode(array(
@@ -99,12 +98,6 @@ class ToolsController extends AdminAppController
             )
         ));
 
-        // eigene bearbeitungs-hinweise bei click auf cancel löschen
-        // if ($object[$objectClass]['currently_updated_by'] == $this->AppAuth->getUserId()) {
-        // $this->$objectClass->id = $id;
-        // $this->$objectClass->saveField('currently_updated_by', 0);
-        // }
-
         die(json_encode(array(
             'status' => 1,
             'msg' => 'ok',
@@ -114,11 +107,13 @@ class ToolsController extends AdminAppController
 
     /*
      * On uploading images are resized to fit to the maximum possibly required ...ImageSizes from app.config.php
+     * return int
      */
-    protected function calculateTmpUploadFileSize()
+    protected function getMaxTmpUploadFileSize()
     {
+
+        $actTmpUploadFileSize = 0;
         $confKey = 'ImageSizes';
-        $actTmpUploadFileSize = Configure::read('app.tmpUploadFileSize');
 
         // get all config keys "*ImageSizes"
         $imageSizes = Configure::read('app');
@@ -138,6 +133,7 @@ class ToolsController extends AdminAppController
             }
         }
 
-        Configure::write('app.tmpUploadFileSize', $actTmpUploadFileSize);
+        return $actTmpUploadFileSize;
+
     }
 }


### PR DESCRIPTION
As the temp image size is now calculated always before applying it, the setting in app.config.php is rendered useless. Maybe remove it? Or make it DB based, so it can be updated after calculation and do the calculation only after app.config.php was changed?