### PR TITLE
travis adaptions for ubuntu trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,8 @@ before_script:
   - curl http://www.foodcoopshop.dev/aktuelles
   - sudo cat /var/log/apache2/www.foodcoopshop.dev_error.log
   # create the command to run by Travis-CI
+  - whoami
+  - getfacl .
   - sudo chmod o+rwx /home/travis/build/foodcoopshop/foodcoopshop
   - echo -e "#!/usr/bin/env bash\nsudo -u www-data -- ./Console/cake test app AllFoodCoopShopTests --stderr" > ./travis-build-command.sh
   - chmod 0777 ./travis-build-command.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,17 @@
 language: php
-dist: precise
+dist: trusty
+sudo: required
 
 php:
-  - 5.5
-  - 5.6
-  - 7.0
   - 7.1
 
 services:
   - mysql
-  
-addons:
-  hosts:
-    - www.foodcoopshop.dev
     
+addons:
+    hosts:
+        - www.foodcoopshop.dev
+
 env:
   - DB=mysql
   
@@ -39,17 +37,29 @@ before_script:
   # enable php-fpm
   - if [[ ${TRAVIS_PHP_VERSION:0:1} == "7" ]]; then sudo cp ./Config/travis/php7.conf ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.d/; fi
   - sudo cp ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf.default ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf
-  - sudo a2enmod rewrite actions fastcgi alias
   - echo "cgi.fix_pathinfo = 1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
-  - ~/.phpenv/versions/$(phpenv version-name)/sbin/php-fpm
+  - sudo ~/.phpenv/versions/$(phpenv version-name)/sbin/php-fpm
   # configure apache virtual hosts
-  - sudo cp -f ./Config/travis/apache /etc/apache2/sites-available/default
-  - sudo sed -e "s?%TRAVIS_BUILD_DIR%?$(pwd)?g" --in-place /etc/apache2/sites-available/default
+  - sudo cp -f ./Config/travis/apache /etc/apache2/sites-available/www.foodcoopshop.dev.conf
+  - sudo sed -e "s?%TRAVIS_BUILD_DIR%?$(pwd)?g" --in-place /etc/apache2/sites-available/www.foodcoopshop.dev.conf
+  - sudo a2dissite 000-default
+  - sudo a2ensite www.foodcoopshop.dev.conf
+  - sudo a2enmod rewrite actions fastcgi alias
+  - sudo chown -R www-data:www-data /home/travis/build/foodcoopshop
+  - sudo chmod o+rx /home/travis
+  - sudo chmod a+w -R /home/travis/build/foodcoopshop/foodcoopshop/files_private
+  - sudo chmod a+w -R /home/travis/build/foodcoopshop/foodcoopshop/tmp
+  - sudo chmod a+w -R /home/travis/build/foodcoopshop/foodcoopshop/webroot/cache
+  - sudo chmod a+w -R /home/travis/build/foodcoopshop/foodcoopshop/webroot/files
+  - sudo chmod a+w -R /home/travis/build/foodcoopshop/foodcoopshop/webroot/tmp
   - sudo service apache2 restart
+  - curl http://www.foodcoopshop.dev
+  - curl http://www.foodcoopshop.dev/aktuelles
+  - sudo cat /var/log/apache2/www.foodcoopshop.dev_error.log
 
 script:
   - ./Console/cake test app AllFoodCoopShopTests --stderr
-
+  
 notifications:
   email: false
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ before_script:
   - sudo a2dissite 000-default
   - sudo a2ensite www.foodcoopshop.dev.conf
   - sudo a2enmod rewrite actions fastcgi alias
-  - sudo chown -R www-data:www-data /home/travis/build/foodcoopshop
+  - sudo chown -R travis:travis /home/travis/build/foodcoopshop
   - sudo chmod o+rx /home/travis
   - sudo chmod a+w -R /home/travis/build/foodcoopshop/foodcoopshop/files_private
   - sudo chmod a+w -R /home/travis/build/foodcoopshop/foodcoopshop/tmp
@@ -56,15 +56,15 @@ before_script:
   - curl http://www.foodcoopshop.dev/aktuelles
   - sudo cat /var/log/apache2/www.foodcoopshop.dev_error.log
   # create the command to run by Travis-CI
-  - whoami
-  - getfacl .
-  - sudo chmod o+rwx /home/travis/build/foodcoopshop/foodcoopshop
-  - echo -e "#!/usr/bin/env bash\nsudo -u www-data -- ./Console/cake test app AllFoodCoopShopTests --stderr" > ./travis-build-command.sh
-  - chmod 0777 ./travis-build-command.sh
-  - sudo chmod o-w /home/travis/build/foodcoopshop/foodcoopshop
+  - groups
+#  - sudo chmod o+rwx /home/travis/build/foodcoopshop/foodcoopshop
+#  - echo -e "#!/usr/bin/env bash\nsudo -u www-data -- ./Console/cake test app AllFoodCoopShopTests --stderr" > ./travis-build-command.sh
+#  - chmod 0777 ./travis-build-command.sh
+#  - sudo chmod o-w /home/travis/build/foodcoopshop/foodcoopshop
 
 script:
-  - ./travis-build-command.sh
+#  - ./travis-build-command.sh
+  - ./Console/cake test app AllFoodCoopShopTests --stderr
   
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,9 +31,9 @@ before_script:
   - npm install -g bower
   - bower install
   - bash ./Console/cake asset_compress build
-  # Apache Install
+  # Apache Install, runs as www-data:www-data
   - sudo apt-get install apache2 libapache2-mod-fastcgi
-  # enable php-fpm
+  # enable php-fpm, runs as travis:travis
   - if [[ ${TRAVIS_PHP_VERSION:0:1} == "7" ]]; then sudo cp ./Config/travis/php7.conf ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.d/; fi
   - sudo cp ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf.default ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf
   - echo "cgi.fix_pathinfo = 1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
@@ -55,15 +55,8 @@ before_script:
   - curl http://www.foodcoopshop.dev
   - curl http://www.foodcoopshop.dev/aktuelles
   - sudo cat /var/log/apache2/www.foodcoopshop.dev_error.log
-  # create the command to run by Travis-CI
-  - groups
-#  - sudo chmod o+rwx /home/travis/build/foodcoopshop/foodcoopshop
-#  - echo -e "#!/usr/bin/env bash\nsudo -u www-data -- ./Console/cake test app AllFoodCoopShopTests --stderr" > ./travis-build-command.sh
-#  - chmod 0777 ./travis-build-command.sh
-#  - sudo chmod o-w /home/travis/build/foodcoopshop/foodcoopshop
 
 script:
-#  - ./travis-build-command.sh
   - ./Console/cake test app AllFoodCoopShopTests --stderr
   
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ dist: trusty
 sudo: required
 
 php:
+  #- 5.5
+  #- 5.6
+  #- 7.0
   - 7.1
 
 services:
@@ -43,17 +46,15 @@ before_script:
   - sudo sed -e "s?%TRAVIS_BUILD_DIR%?$(pwd)?g" --in-place /etc/apache2/sites-available/www.foodcoopshop.dev.conf
   - sudo a2dissite 000-default
   - sudo a2ensite www.foodcoopshop.dev.conf
-  - sudo a2enmod rewrite actions fastcgi alias
-  - sudo chown -R travis:travis /home/travis/build/foodcoopshop
-  - sudo chmod o+rx /home/travis
-  - sudo chmod a+w -R /home/travis/build/foodcoopshop/foodcoopshop/files_private
-  - sudo chmod a+w -R /home/travis/build/foodcoopshop/foodcoopshop/tmp
-  - sudo chmod a+w -R /home/travis/build/foodcoopshop/foodcoopshop/webroot/cache
-  - sudo chmod a+w -R /home/travis/build/foodcoopshop/foodcoopshop/webroot/files
-  - sudo chmod a+w -R /home/travis/build/foodcoopshop/foodcoopshop/webroot/tmp
+  #- sudo a2enmod rewrite actions fastcgi alias
+  #- sudo chown -R travis:travis /home/travis/build/foodcoopshop
+  #- sudo chmod o+rx /home/travis
+  #- sudo chmod a+w -R /home/travis/build/foodcoopshop/foodcoopshop/files_private
+  #- sudo chmod a+w -R /home/travis/build/foodcoopshop/foodcoopshop/tmp
+  #- sudo chmod a+w -R /home/travis/build/foodcoopshop/foodcoopshop/webroot/cache
+  #- sudo chmod a+w -R /home/travis/build/foodcoopshop/foodcoopshop/webroot/files
+  #- sudo chmod a+w -R /home/travis/build/foodcoopshop/foodcoopshop/webroot/tmp
   - sudo service apache2 restart
-  - curl http://www.foodcoopshop.dev
-  - curl http://www.foodcoopshop.dev/aktuelles
   - sudo cat /var/log/apache2/www.foodcoopshop.dev_error.log
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ before_script:
   - if [[ ${TRAVIS_PHP_VERSION:0:1} == "7" ]]; then sudo cp ./Config/travis/php7.conf ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.d/; fi
   - if [[ ${TRAVIS_PHP_VERSION:0:1} == "5" ]]; then sudo mkdir ~/.phpenv/versions/$(phpenv version-name)/etc/fpm.d/; sudo cp ./Config/travis/php7.conf ~/.phpenv/versions/$(phpenv version-name)/etc/fpm.d/; fi
   - sudo cp ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf.default ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf
-  #- if [[ ${TRAVIS_PHP_VERSION:0:1} == "5" ]]; then sudo echo -e 'include=etc/fpm.d/*.conf' >> ~/.phpenv/versions/$(phpenv version-name)/etc/fpm.d/php7.conf; fi
+  - if [[ ${TRAVIS_PHP_VERSION:0:1} == "5" ]]; then sudo echo -e 'include=etc/fpm.d/*.conf' >> ~/.phpenv/versions/$(phpenv version-name)/etc/fpm.d/php-fpm.conf; fi
   - echo "cgi.fix_pathinfo = 1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
   - sudo ~/.phpenv/versions/$(phpenv version-name)/sbin/php-fpm
   # configure apache virtual hosts

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,10 +37,11 @@ before_script:
   # Apache Install, runs as www-data:www-data
   - sudo apt-get install apache2 libapache2-mod-fastcgi
   # enable php-fpm, runs as travis:travis
-  - if [[ ${TRAVIS_PHP_VERSION:0:1} == "7" ]]; then sudo cp ./Config/travis/php7.conf ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.d/; fi
-  - if [[ ${TRAVIS_PHP_VERSION:0:1} == "5" ]]; then sudo mkdir ~/.phpenv/versions/$(phpenv version-name)/etc/fpm.d/; sudo cp ./Config/travis/php7.conf ~/.phpenv/versions/$(phpenv version-name)/etc/fpm.d/; fi
+  - if [[ ${TRAVIS_PHP_VERSION:0:1} == "5" ]]; then sudo mkdir ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.d/; fi
+  #- if [[ ${TRAVIS_PHP_VERSION:0:1} == "7" ]]; then sudo cp ./Config/travis/php7.conf ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.d/; fi
+  - sudo cp ./Config/travis/php7.conf ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.d/
   - sudo cp ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf.default ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf
-  - if [[ ${TRAVIS_PHP_VERSION:0:1} == "5" ]]; then sudo echo -e 'include=etc/fpm.d/*.conf' >> ~/.phpenv/versions/$(phpenv version-name)/etc/fpm.d/php-fpm.conf; fi
+  - if [[ ${TRAVIS_PHP_VERSION:0:1} == "5" ]]; then sudo sed -e "s?;include=etc/fpm.d/*.conf?include=etc/php-fpm.d/*.conf?g" --in-place ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf; fi
   - echo "cgi.fix_pathinfo = 1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
   - sudo ~/.phpenv/versions/$(phpenv version-name)/sbin/php-fpm
   # configure apache virtual hosts

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ dist: trusty
 sudo: required
 
 php:
-  - 5.5
-  - 5.6
-  - 7.0
+  #- 5.5
+  #- 5.6
+  #- 7.0
   - 7.1
 
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ before_script:
   - echo -e '#!/usr/bin/env bash\nexit 0' | sudo tee /usr/sbin/sendmail
   - echo 'sendmail_path = "/usr/sbin/sendmail -t -i "' | sudo tee "/home/travis/.phpenv/versions/`php -i | grep "PHP Version" | head -n 1 | grep -o -P '\d+\.\d+\.\d+.*'`/etc/conf.d/sendmail.ini"
   # start build
-  - git clone --depth 1 git://github.com/foodcoopshop/foodcoopshop
   - mysql -e 'CREATE DATABASE foodcoopshop_test;'
   - mysql foodcoopshop_test < ./Config/sql/_installation/clean-db-structure.sql
   - mysql foodcoopshop_test < ./Test/test_files/Config/sql/test-db-data.sql
@@ -56,9 +55,12 @@ before_script:
   - curl http://www.foodcoopshop.dev
   - curl http://www.foodcoopshop.dev/aktuelles
   - sudo cat /var/log/apache2/www.foodcoopshop.dev_error.log
+  # create the command to run by Travis-CI
+  - sudo echo '#!/usr/bin/env bash\nsudo -u www-data -- ./Console/cake test app AllFoodCoopShopTests --stderr' > ./travis-build-command.sh
+  - sudo chmod a+rx ./travis-build-command.sh
 
 script:
-  - ./Console/cake test app AllFoodCoopShopTests --stderr
+  - ./travis-build-command.sh
   
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ dist: trusty
 sudo: required
 
 php:
-  #- 5.5
-  #- 5.6
-  #- 7.0
+  - 5.5
+  - 5.6
+  - 7.0
   - 7.1
 
 services:
@@ -37,7 +37,8 @@ before_script:
   # Apache Install, runs as www-data:www-data
   - sudo apt-get install apache2 libapache2-mod-fastcgi
   # enable php-fpm, runs as travis:travis
-  - if [[ ${TRAVIS_PHP_VERSION:0:1} == "7" ]]; then sudo cp ./Config/travis/php7.conf ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.d/; fi
+  #- if [[ ${TRAVIS_PHP_VERSION:0:1} == "7" ]]; then sudo cp ./Config/travis/php7.conf ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.d/; fi
+  - sudo cp ./Config/travis/php7.conf ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.d/
   - sudo cp ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf.default ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf
   - echo "cgi.fix_pathinfo = 1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
   - sudo ~/.phpenv/versions/$(phpenv version-name)/sbin/php-fpm

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ before_script:
   - sudo a2ensite www.foodcoopshop.dev.conf
   - sudo a2enmod rewrite actions fastcgi alias
   - sudo chown -R travis:travis /home/travis/build/foodcoopshop
-  #- sudo chmod o+rx /home/travis
+  - sudo chmod o+rx /home/travis
   #- sudo chmod a+w -R /home/travis/build/foodcoopshop/foodcoopshop/files_private
   #- sudo chmod a+w -R /home/travis/build/foodcoopshop/foodcoopshop/tmp
   #- sudo chmod a+w -R /home/travis/build/foodcoopshop/foodcoopshop/webroot/cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,11 +37,14 @@ before_script:
   # Apache Install, runs as www-data:www-data
   - sudo apt-get install apache2 libapache2-mod-fastcgi
   # enable php-fpm, runs as travis:travis
+  # - if [[ ${TRAVIS_PHP_VERSION:0:1} == "5" ]]; then sudo addgroup nobody; sudo adduser nobody nobody; fi
   - if [[ ${TRAVIS_PHP_VERSION:0:1} == "5" ]]; then sudo mkdir ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.d/; sudo chmod 0755 ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.d/; fi
   #- if [[ ${TRAVIS_PHP_VERSION:0:1} == "7" ]]; then sudo cp ./Config/travis/php7.conf ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.d/; fi
   - sudo cp ./Config/travis/php7.conf ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.d/
   - sudo cp ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf.default ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf
-  - if [[ ${TRAVIS_PHP_VERSION:0:1} == "5" ]]; then sudo sed -e "s?;include=etc/fpm.d/*.conf?include=~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.d/*.conf?g" --in-place ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf; fi
+  #- if [[ ${TRAVIS_PHP_VERSION:0:1} == "5" ]]; then sudo sed -e "s?;include=etc/fpm.d/*.conf?include=~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.d/*.conf?g" --in-place ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf; fi
+  - if [[ ${TRAVIS_PHP_VERSION:0:1} == "5" ]]; then sudo sed -e "s?user = nobody?user = travis" --in-place ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf; fi
+  - if [[ ${TRAVIS_PHP_VERSION:0:1} == "5" ]]; then sudo sed -e "s?group = nobody?group = travis" --in-place ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf; fi
   - echo "cgi.fix_pathinfo = 1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
   - sudo ~/.phpenv/versions/$(phpenv version-name)/sbin/php-fpm
   # configure apache virtual hosts

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ before_script:
   - sudo a2dissite 000-default
   - sudo a2ensite www.foodcoopshop.dev.conf
   - sudo a2enmod rewrite actions fastcgi alias
-  #- sudo chown -R travis:travis /home/travis/build/foodcoopshop
+  - sudo chown -R travis:travis /home/travis/build/foodcoopshop
   #- sudo chmod o+rx /home/travis
   #- sudo chmod a+w -R /home/travis/build/foodcoopshop/foodcoopshop/files_private
   #- sudo chmod a+w -R /home/travis/build/foodcoopshop/foodcoopshop/tmp

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,9 +37,10 @@ before_script:
   # Apache Install, runs as www-data:www-data
   - sudo apt-get install apache2 libapache2-mod-fastcgi
   # enable php-fpm, runs as travis:travis
-  #- if [[ ${TRAVIS_PHP_VERSION:0:1} == "7" ]]; then sudo cp ./Config/travis/php7.conf ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.d/; fi
-  - sudo cp ./Config/travis/php7.conf ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.d/
+  - if [[ ${TRAVIS_PHP_VERSION:0:1} == "7" ]]; then sudo cp ./Config/travis/php7.conf ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.d/; fi
+  - if [[ ${TRAVIS_PHP_VERSION:0:1} == "5" ]]; then sudo mkdir ~/.phpenv/versions/$(phpenv version-name)/etc/fpm.d/; sudo cp ./Config/travis/php7.conf ~/.phpenv/versions/$(phpenv version-name)/etc/fpm.d/; fi
   - sudo cp ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf.default ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf
+  #- if [[ ${TRAVIS_PHP_VERSION:0:1} == "5" ]]; then sudo echo -e 'include=etc/fpm.d/*.conf' >> ~/.phpenv/versions/$(phpenv version-name)/etc/fpm.d/php7.conf; fi
   - echo "cgi.fix_pathinfo = 1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
   - sudo ~/.phpenv/versions/$(phpenv version-name)/sbin/php-fpm
   # configure apache virtual hosts

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,9 +37,10 @@ before_script:
   # Apache Install, runs as www-data:www-data
   - sudo apt-get install apache2 libapache2-mod-fastcgi
   # enable php-fpm, runs as travis:travis
-  - if [[ ${TRAVIS_PHP_VERSION:0:1} == "5" ]]; then sudo mkdir ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.d/; sudo chmod 0755 ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.d/; fi
-  - sudo cp ./Config/travis/php7.conf ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.d/
   - sudo cp ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf.default ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf
+  # for PHP7 inclusion of additional config files works
+  - if [[ ${TRAVIS_PHP_VERSION:0:1} == "7" ]]; then sudo sudo cp ./Config/travis/php7.conf ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.d/; fi
+  # for PHP5 modify main config file
   - if [[ ${TRAVIS_PHP_VERSION:0:1} == "5" ]]; then sudo sed -e "s?user = nobody?user = travis?g" --in-place ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf; fi
   - if [[ ${TRAVIS_PHP_VERSION:0:1} == "5" ]]; then sudo sed -e "s?group = nobody?group = travis?g" --in-place ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf; fi
   - echo "cgi.fix_pathinfo = 1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,8 +43,8 @@ before_script:
   - sudo cp ./Config/travis/php7.conf ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.d/
   - sudo cp ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf.default ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf
   #- if [[ ${TRAVIS_PHP_VERSION:0:1} == "5" ]]; then sudo sed -e "s?;include=etc/fpm.d/*.conf?include=~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.d/*.conf?g" --in-place ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf; fi
-  - if [[ ${TRAVIS_PHP_VERSION:0:1} == "5" ]]; then sudo sed -e "s?user = nobody?user = travis" --in-place ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf; fi
-  - if [[ ${TRAVIS_PHP_VERSION:0:1} == "5" ]]; then sudo sed -e "s?group = nobody?group = travis" --in-place ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf; fi
+  - if [[ ${TRAVIS_PHP_VERSION:0:1} == "5" ]]; then sudo sed -e "s?user = nobody?user = travis?g" --in-place ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf; fi
+  - if [[ ${TRAVIS_PHP_VERSION:0:1} == "5" ]]; then sudo sed -e "s?group = nobody?group = travis?g" --in-place ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf; fi
   - echo "cgi.fix_pathinfo = 1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
   - sudo ~/.phpenv/versions/$(phpenv version-name)/sbin/php-fpm
   # configure apache virtual hosts

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ before_script:
   - sudo sed -e "s?%TRAVIS_BUILD_DIR%?$(pwd)?g" --in-place /etc/apache2/sites-available/www.foodcoopshop.dev.conf
   - sudo a2dissite 000-default
   - sudo a2ensite www.foodcoopshop.dev.conf
-  #- sudo a2enmod rewrite actions fastcgi alias
+  - sudo a2enmod rewrite actions fastcgi alias
   #- sudo chown -R travis:travis /home/travis/build/foodcoopshop
   #- sudo chmod o+rx /home/travis
   #- sudo chmod a+w -R /home/travis/build/foodcoopshop/foodcoopshop/files_private

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ dist: trusty
 sudo: required
 
 php:
-  #- 5.5
-  #- 5.6
-  #- 7.0
+  - 5.5
+  - 5.6
+  - 7.0
   - 7.1
 
 services:
@@ -49,13 +49,8 @@ before_script:
   - sudo a2enmod rewrite actions fastcgi alias
   - sudo chown -R travis:travis /home/travis/build/foodcoopshop
   - sudo chmod o+rx /home/travis
-  #- sudo chmod a+w -R /home/travis/build/foodcoopshop/foodcoopshop/files_private
-  #- sudo chmod a+w -R /home/travis/build/foodcoopshop/foodcoopshop/tmp
-  #- sudo chmod a+w -R /home/travis/build/foodcoopshop/foodcoopshop/webroot/cache
-  #- sudo chmod a+w -R /home/travis/build/foodcoopshop/foodcoopshop/webroot/files
-  #- sudo chmod a+w -R /home/travis/build/foodcoopshop/foodcoopshop/webroot/tmp
   - sudo service apache2 restart
-  - sudo cat /var/log/apache2/www.foodcoopshop.dev_error.log
+  #- sudo cat /var/log/apache2/www.foodcoopshop.dev_error.log
 
 script:
   - ./Console/cake test app AllFoodCoopShopTests --stderr

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,8 +56,10 @@ before_script:
   - curl http://www.foodcoopshop.dev/aktuelles
   - sudo cat /var/log/apache2/www.foodcoopshop.dev_error.log
   # create the command to run by Travis-CI
-  - sudo echo -e '#!/usr/bin/env bash\nsudo -u www-data -- ./Console/cake test app AllFoodCoopShopTests --stderr' > ./travis-build-command.sh
-  - sudo chmod a+rx ./travis-build-command.sh
+  - sudo chmod o+rwx /home/travis/build/foodcoopshop/foodcoopshop
+  - echo -e "#!/usr/bin/env bash\nsudo -u www-data -- ./Console/cake test app AllFoodCoopShopTests --stderr" > ./travis-build-command.sh
+  - chmod 0777 ./travis-build-command.sh
+  - sudo chmod o-w /home/travis/build/foodcoopshop/foodcoopshop
 
 script:
   - ./travis-build-command.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,12 +37,9 @@ before_script:
   # Apache Install, runs as www-data:www-data
   - sudo apt-get install apache2 libapache2-mod-fastcgi
   # enable php-fpm, runs as travis:travis
-  # - if [[ ${TRAVIS_PHP_VERSION:0:1} == "5" ]]; then sudo addgroup nobody; sudo adduser nobody nobody; fi
   - if [[ ${TRAVIS_PHP_VERSION:0:1} == "5" ]]; then sudo mkdir ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.d/; sudo chmod 0755 ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.d/; fi
-  #- if [[ ${TRAVIS_PHP_VERSION:0:1} == "7" ]]; then sudo cp ./Config/travis/php7.conf ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.d/; fi
   - sudo cp ./Config/travis/php7.conf ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.d/
   - sudo cp ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf.default ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf
-  #- if [[ ${TRAVIS_PHP_VERSION:0:1} == "5" ]]; then sudo sed -e "s?;include=etc/fpm.d/*.conf?include=~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.d/*.conf?g" --in-place ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf; fi
   - if [[ ${TRAVIS_PHP_VERSION:0:1} == "5" ]]; then sudo sed -e "s?user = nobody?user = travis?g" --in-place ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf; fi
   - if [[ ${TRAVIS_PHP_VERSION:0:1} == "5" ]]; then sudo sed -e "s?group = nobody?group = travis?g" --in-place ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf; fi
   - echo "cgi.fix_pathinfo = 1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ before_script:
   - curl http://www.foodcoopshop.dev/aktuelles
   - sudo cat /var/log/apache2/www.foodcoopshop.dev_error.log
   # create the command to run by Travis-CI
-  - sudo echo '#!/usr/bin/env bash\nsudo -u www-data -- ./Console/cake test app AllFoodCoopShopTests --stderr' > ./travis-build-command.sh
+  - sudo echo -e '#!/usr/bin/env bash\nsudo -u www-data -- ./Console/cake test app AllFoodCoopShopTests --stderr' > ./travis-build-command.sh
   - sudo chmod a+rx ./travis-build-command.sh
 
 script:
@@ -64,4 +64,3 @@ script:
   
 notifications:
   email: false
-  

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,11 +37,11 @@ before_script:
   # Apache Install, runs as www-data:www-data
   - sudo apt-get install apache2 libapache2-mod-fastcgi
   # enable php-fpm, runs as travis:travis
-  - if [[ ${TRAVIS_PHP_VERSION:0:1} == "5" ]]; then sudo mkdir ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.d/; fi
+  - if [[ ${TRAVIS_PHP_VERSION:0:1} == "5" ]]; then sudo mkdir ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.d/; sudo chmod 0755 ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.d/; fi
   #- if [[ ${TRAVIS_PHP_VERSION:0:1} == "7" ]]; then sudo cp ./Config/travis/php7.conf ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.d/; fi
   - sudo cp ./Config/travis/php7.conf ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.d/
   - sudo cp ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf.default ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf
-  - if [[ ${TRAVIS_PHP_VERSION:0:1} == "5" ]]; then sudo sed -e "s?;include=etc/fpm.d/*.conf?include=etc/php-fpm.d/*.conf?g" --in-place ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf; fi
+  - if [[ ${TRAVIS_PHP_VERSION:0:1} == "5" ]]; then sudo sed -e "s?;include=etc/fpm.d/*.conf?include=~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.d/*.conf?g" --in-place ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf; fi
   - echo "cgi.fix_pathinfo = 1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
   - sudo ~/.phpenv/versions/$(phpenv version-name)/sbin/php-fpm
   # configure apache virtual hosts

--- a/Config/travis/apache
+++ b/Config/travis/apache
@@ -1,21 +1,27 @@
-<VirtualHost *:80>
-
-  DocumentRoot %TRAVIS_BUILD_DIR%/webroot
-  ServerName www.foodcoopshop.dev
-
-  <Directory "%TRAVIS_BUILD_DIR%">
-    Options FollowSymLinks MultiViews ExecCGI
-    AllowOverride All
-    Order deny,allow
-    Allow from all
-  </Directory>
-
-  # Wire up Apache to use Travis CI's php-fpm.
+<VirtualHost www.foodcoopshop.dev:80>
+    ServerName www.foodcoopshop.dev
+    DocumentRoot %TRAVIS_BUILD_DIR%/webroot
+    
+    <Directory %TRAVIS_BUILD_DIR%/webroot>
+      Options FollowSymLinks MultiViews ExecCGI
+      AllowOverride All
+      Require all granted
+    </Directory>
+    
   <IfModule mod_fastcgi.c>
     AddHandler php5-fcgi .php
     Action php5-fcgi /php5-fcgi
     Alias /php5-fcgi /usr/lib/cgi-bin/php5-fcgi
     FastCgiExternalServer /usr/lib/cgi-bin/php5-fcgi -host 127.0.0.1:9000 -pass-header Authorization
-  </IfModule>
+    
+    <Directory /usr/lib/cgi-bin>
+        Require all granted
+    </Directory>
+    
+  </IfModule>   
 
+    LogLevel warn
+    ErrorLog /var/log/apache2/www.foodcoopshop.dev_error.log
+    CustomLog /var/log/apache2/www.foodcoopshop.dev_access.log combined
+    ServerSignature Off
 </VirtualHost>

--- a/Config/travis/php7.conf
+++ b/Config/travis/php7.conf
@@ -20,7 +20,7 @@
 ; Note: The user is mandatory. If the group is not set, the default user's group
 ;       will be used.
 user = travis
-#group = www-data
+;group = www-data
 
 ; The address on which to accept FastCGI requests.
 ; Valid syntaxes are:

--- a/Config/travis/php7.conf
+++ b/Config/travis/php7.conf
@@ -19,8 +19,8 @@
 ; Unix user/group of processes
 ; Note: The user is mandatory. If the group is not set, the default user's group
 ;       will be used.
-user = www-data
-group = www-data
+user = travis
+#group = www-data
 
 ; The address on which to accept FastCGI requests.
 ; Valid syntaxes are:

--- a/Config/travis/php7.conf
+++ b/Config/travis/php7.conf
@@ -20,7 +20,7 @@
 ; Note: The user is mandatory. If the group is not set, the default user's group
 ;       will be used.
 user = travis
-;group = www-data
+group = travis
 
 ; The address on which to accept FastCGI requests.
 ; Valid syntaxes are:


### PR DESCRIPTION
maybe you can help me, michael? the virtual host is working (see output in line 931 of travis log https://travis-ci.org/foodcoopshop/foodcoopshop/builds/256673980)

but when the host is called by the tests, there is a problem with the cache permissions.
SplFileInfo::openFile(/home/travis/build/foodcoopshop/foodcoopshop/tmp/cache/persistent/myapp_cake_core_method_cache): failed to open stream: Permission denied
