### PR TITLE
order states

### DIFF
--- a/config/localized_config.php
+++ b/config/localized_config.php
@@ -29,7 +29,7 @@ return [
         'manufacturerComponensationInfoText' => __('This_order_contains_the_variable_member_fee.'),
         'visibleOrderStates' => [
             ORDER_STATE_OPEN => __('order_state_open'),
-            ORDER_STATE_CASH_FREE => __('order_state_closed'),
+            ORDER_STATE_CLOSED => __('order_state_closed'),
         ],
         'currencyName' => Configure::read('app.htmlHelper')->getCurrencyName(Configure::read('appDb.FCS_CURRENCY_SYMBOL'))
     ]


### PR DESCRIPTION
I might be wrong, but this doesn't add up.
Look at the app_config. There you have:
	define('ORDER_STATE_OPEN', 3);
	define('ORDER_STATE_CLOSED', 5);
	define('ORDER_STATE_CASH_FREE', 1);
	define('ORDER_STATE_CASH', 2);
	define('ORDER_STATE_CANCELLED', 6);
Which isn't right too IMO, since closing an order causes an update on orders table setting current_state to 2.