### PR TITLE
Update ManufacturersTable.php

### DIFF
--- a/src/Model/Table/ManufacturersTable.php
+++ b/src/Model/Table/ManufacturersTable.php
@@ -539,7 +539,7 @@ class ManufacturersTable extends AppTable
             {$orderStateCondition}
             {$includeStockProductCondition}
             {$orderDetailCondition}
-            ORDER BY {$orderClause}, DATE_FORMAT (od.created, '%d.%m.%Y, %H:%i') DESC;";
+            ORDER BY {$orderClause}, DATE_FORMAT(od.created, '%d.%m.%Y, %H:%i') DESC;";
 
         $statement = $this->getConnection()->prepare($sql);
         $statement->execute($params);


### PR DESCRIPTION
Fix #724

Ein Leerzeichen nach der DATE_FORMAT-Funktion führt zu einem Fehler beim Ausführen von SQL Statements. Weil die Funktion dann nicht mehr richtig aufgelöst werden kann.

Du kannst dem Projekt zu mehr Sichtbarkeit verhelfen, in dem du ihm einen Stern ⭐ gibst. Danke!
You can help making this open source project more visible on GitHub by starring ⭐ it. Thank you!
