### PR TITLE
Fix backupscript if non default port is used

### DIFF
--- a/src/Shell/BackupDatabaseShell.php
+++ b/src/Shell/BackupDatabaseShell.php
@@ -52,9 +52,10 @@ class BackupDatabaseShell extends AppShell
         $configFileObject = new File($configFile);
         $configFileContent = '[mysqldump]
 host=%host%
+port=%port%
 user=%user%
 password="%password%"';
-        $configFileContent = str_replace(['%host%', '%user%', '%password%'], [$dbConfig['host'], $dbConfig['username'], $dbConfig['password']], $configFileContent);
+        $configFileContent = str_replace(['%host%', '%port%', '%user%', '%password%'], [$dbConfig['host'], $dbConfig['port'], $dbConfig['username'], $dbConfig['password']], $configFileContent);
         $configFileObject->write($configFileContent);
 
         $cmdString = Configure::read('app.mysqlDumpCommand');

--- a/src/Shell/BackupDatabaseShell.php
+++ b/src/Shell/BackupDatabaseShell.php
@@ -52,10 +52,14 @@ class BackupDatabaseShell extends AppShell
         $configFileObject = new File($configFile);
         $configFileContent = '[mysqldump]
 host=%host%
-port=%port%
 user=%user%
-password="%password%"';
-        $configFileContent = str_replace(['%host%', '%port%', '%user%', '%password%'], [$dbConfig['host'], $dbConfig['port'], $dbConfig['username'], $dbConfig['password']], $configFileContent);
+password="%password%"
+';
+        $configFileContent = str_replace(['%host%', '%user%', '%password%'], [$dbConfig['host'], $dbConfig['username'], $dbConfig['password']], $configFileContent);
+        if (isset($dbConfig['port'])) {
+            $configFileContent .= 'port=' . $dbConfig['port'];
+        }
+
         $configFileObject->write($configFileContent);
 
         $cmdString = Configure::read('app.mysqlDumpCommand');


### PR DESCRIPTION
Add port to temporary database config file.
Unsure if it works if no port is provided in custom_config file.
