### PR TITLE
Make showing value add tax in success mail optional

### DIFF
--- a/config/app_config.php
+++ b/config/app_config.php
@@ -180,6 +180,8 @@ return [
 
         'isZeroTaxEnabled' => true,
 
+        'sendTaxViaMail' => true,
+
         // additionalTextForInvoice - for invoices to customers (not available if hello cash is used!)
         'additionalTextForInvoice' => '',
 

--- a/templates/email/html/order_successful.php
+++ b/templates/email/html/order_successful.php
@@ -61,9 +61,14 @@ foreach($cart['CartProducts'] as $pickupDay => $cartProducts) {
             </td></tr>
         <?php } ?>
 
-        <tr><td style="padding-top:20px;">
-            <?php echo __('Including_vat'); ?> <?php echo $this->MyNumber->formatAsCurrency($appAuth->Cart->getTaxSum()); ?>
-        </td></tr>
+
+        <?php if (Configure::read('app.sendTaxViaMail')) { ?>
+
+            <tr><td style="padding-top:20px;">
+                <?php echo __('Including_vat'); ?> <?php echo $this->MyNumber->formatAsCurrency($appAuth->Cart->getTaxSum()); ?>
+            </td></tr>
+
+        <?php } ?>
 
         <tr><td>
             <?php

--- a/templates/email/html/order_successful_self_service.php
+++ b/templates/email/html/order_successful_self_service.php
@@ -51,12 +51,21 @@ foreach($cart['CartProducts'] as $pickupDay => $cartProducts) {
 <?php echo $this->element('email/tableHead'); ?>
     <tbody>
 
+
         <tr><td style="padding-top:20px;">
-            <?php echo __('Including_vat'); ?> <?php echo $this->MyNumber->formatAsCurrency($appAuth->Cart->getTaxSum()); ?>
-        </td></tr>
+
+
+        <?php if (Configure::read('app.sendTaxViaMail')) { ?>
+
+
+                <?php echo __('Including_vat'); ?> <?php echo $this->MyNumber->formatAsCurrency($appAuth->Cart->getTaxSum()); ?>
+            </td></tr>
 
         <tr><td>
             <?php
+
+                }
+
                 if ($this->MyHtml->paymentIsCashless()) {
                     echo __('The_amount_was_reduced_from_your_credit_balance.');
                 } else {


### PR DESCRIPTION
Depending on the value add tax limit (Umsatzsteuergrenze) it is in Germany not necessary transfer taxes and therefor not necessary to show them in the mails. This commit provides an option in the config to turn showing taxes on and off.