### PR TITLE
Updated: Make showing value add tax in success mail optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@
 
 Das Format basiert auf [keepachangelog.com](http://keepachangelog.com) und verwendet [Semantic Versioning](http://semver.org/).
 
+### Herzlichen Dank an alle beteiligten Personen
+* <img src="https://github.com/MaxGitHubAccount.png" width="20"> [MaxGitHubAccount](https://github.com/MaxGitHubAccount)
+* <img src="https://github.com/mrothauer.png" width="20"> [mrothauer](https://github.com/mrothauer)
+
+### Neue Funktionen / Verbesserungen
+- Die Umsatzsteuer in der Bestellbestätigung kann nun mittels `app.showTaxInOrderConfirmationEmail => false` ausgeblendet werden. [PR#869](https://github.com/foodcoopshop/foodcoopshop/pull/869) <a href="https://github.com/MaxGitHubAccount"><img src="https://github.com/MaxGitHubAccount.png" width="20"></a>
+
+
 # Unveröffentlichte Version
 
 ### Herzlichen Dank an alle beteiligten Personen

--- a/config/app_config.php
+++ b/config/app_config.php
@@ -180,6 +180,8 @@ return [
 
         'isZeroTaxEnabled' => true,
 
+        'sendTaxViaMail' => true,
+
         // additionalTextForInvoice - for invoices to customers (not available if hello cash is used!)
         'additionalTextForInvoice' => '',
 

--- a/config/app_config.php
+++ b/config/app_config.php
@@ -180,7 +180,7 @@ return [
 
         'isZeroTaxEnabled' => true,
 
-        'sendTaxViaMail' => true,
+        'showTaxInOrderConfirmationEmail' => true,
 
         // additionalTextForInvoice - for invoices to customers (not available if hello cash is used!)
         'additionalTextForInvoice' => '',

--- a/plugins/Admin/templates/Configurations/index.php
+++ b/plugins/Admin/templates/Configurations/index.php
@@ -361,6 +361,11 @@ $this->element('addScript', [
         ?>
 
         <tr>
+            <td>app.showTaxInOrderConfirmationEmail</td>
+            <td><?php echo Configure::read('app.showTaxInOrderConfirmationEmail') ? __d('admin', 'yes') : __d('admin', 'no'); ?></td>
+        </tr>
+
+        <tr>
             <td>app.emailErrorLoggingEnabled</td>
             <td><?php echo Configure::read('app.emailErrorLoggingEnabled') ? __d('admin', 'yes') : __d('admin', 'no'); ?></td>
         </tr>

--- a/templates/email/html/order_successful.php
+++ b/templates/email/html/order_successful.php
@@ -61,9 +61,14 @@ foreach($cart['CartProducts'] as $pickupDay => $cartProducts) {
             </td></tr>
         <?php } ?>
 
-        <tr><td style="padding-top:20px;">
-            <?php echo __('Including_vat'); ?> <?php echo $this->MyNumber->formatAsCurrency($appAuth->Cart->getTaxSum()); ?>
-        </td></tr>
+
+        <?php if (Configure::read('app.sendTaxViaMail')) { ?>
+
+            <tr><td style="padding-top:20px;">
+                <?php echo __('Including_vat'); ?> <?php echo $this->MyNumber->formatAsCurrency($appAuth->Cart->getTaxSum()); ?>
+            </td></tr>
+
+        <?php } ?>
 
         <tr><td>
             <?php

--- a/templates/email/html/order_successful.php
+++ b/templates/email/html/order_successful.php
@@ -62,7 +62,7 @@ foreach($cart['CartProducts'] as $pickupDay => $cartProducts) {
         <?php } ?>
 
 
-        <?php if (Configure::read('app.sendTaxViaMail')) { ?>
+        <?php if (Configure::read('app.showTaxInOrderConfirmationEmail')) { ?>
 
             <tr><td style="padding-top:20px;">
                 <?php echo __('Including_vat'); ?> <?php echo $this->MyNumber->formatAsCurrency($appAuth->Cart->getTaxSum()); ?>

--- a/templates/email/html/order_successful_self_service.php
+++ b/templates/email/html/order_successful_self_service.php
@@ -52,20 +52,16 @@ foreach($cart['CartProducts'] as $pickupDay => $cartProducts) {
     <tbody>
 
 
-        <tr><td style="padding-top:20px;">
+        <?php if (Configure::read('app.showTaxInOrderConfirmationEmail')) { ?>
 
-
-        <?php if (Configure::read('app.sendTaxViaMail')) { ?>
-
-
+            <tr><td style="padding-top:20px;">
                 <?php echo __('Including_vat'); ?> <?php echo $this->MyNumber->formatAsCurrency($appAuth->Cart->getTaxSum()); ?>
             </td></tr>
 
+        <?php } ?>
+
         <tr><td>
             <?php
-
-                }
-
                 if ($this->MyHtml->paymentIsCashless()) {
                     echo __('The_amount_was_reduced_from_your_credit_balance.');
                 } else {

--- a/templates/email/html/order_successful_self_service.php
+++ b/templates/email/html/order_successful_self_service.php
@@ -51,12 +51,21 @@ foreach($cart['CartProducts'] as $pickupDay => $cartProducts) {
 <?php echo $this->element('email/tableHead'); ?>
     <tbody>
 
+
         <tr><td style="padding-top:20px;">
-            <?php echo __('Including_vat'); ?> <?php echo $this->MyNumber->formatAsCurrency($appAuth->Cart->getTaxSum()); ?>
-        </td></tr>
+
+
+        <?php if (Configure::read('app.sendTaxViaMail')) { ?>
+
+
+                <?php echo __('Including_vat'); ?> <?php echo $this->MyNumber->formatAsCurrency($appAuth->Cart->getTaxSum()); ?>
+            </td></tr>
 
         <tr><td>
             <?php
+
+                }
+
                 if ($this->MyHtml->paymentIsCashless()) {
                     echo __('The_amount_was_reduced_from_your_credit_balance.');
                 } else {


### PR DESCRIPTION
Depending on the value add tax limit (Umsatzsteuergrenze) it is in Germany not necessary transfer taxes and therefor not necessary to show them in the mails. This commit provides an option in the config to turn showing taxes on and off.

@MaxGitHubAccount Thank you for your PR. Sorry, I wanted to add some commits to your PR and I ended up in creating a new branch and therefore this new PR.

I made some code cleaning.
