### PR TITLE
#1093: SB - Fokus zurück in Suchfeld bei Abbruch des Einkauf Abschließen Dialogs

### DIFF
--- a/webroot/js/modal/modal-self-service-confirm-dialog-paymenttype-details.js
+++ b/webroot/js/modal/modal-self-service-confirm-dialog-paymenttype-details.js
@@ -42,6 +42,9 @@ foodcoopshop.ModalSelfServicePaymenttypeDetailsDialog = {
 
         $('btn-outline-light').on('click', function () {
             foodcoopshop.ModalSelfServicePaymenttypeDetailsDialog.getCloseHandler(modalSelector);
+        });
+        $('btn-close').on('click', function () {
+            foodcoopshop.ModalSelfServicePaymenttypeDetailsDialog.getCloseHandler(modalSelector);
         }); 
 
         new bootstrap.Modal(document.getElementById(modalSelector.replace(/#/, ''))).show();
@@ -49,6 +52,7 @@ foodcoopshop.ModalSelfServicePaymenttypeDetailsDialog = {
 
     getCloseHandler : function(modalSelector) {
         foodcoopshop.Modal.destroy($('#self-service-confirm-dialog-paymenttype-details'));
+        foodcoopshop.SelfService.setFocusToSearchInputField();
     },
     
 };

--- a/webroot/js/modal/modal-self-service-confirm-dialog.js
+++ b/webroot/js/modal/modal-self-service-confirm-dialog.js
@@ -45,6 +45,14 @@ foodcoopshop.ModalSelfServiceConfirmDialog = {
         $('button.btn-success.no-auto-bind').on('click', function () {
             foodcoopshop.ModalSelfServicePaymenttypeDetailsDialog.getOpenHandler('#self-service-confirm-dialog-paymenttype-details', $(this).text(), $(this).attr('value'));
         });  
+
+        $('btn-outline-light').on('click', function () {
+            foodcoopshop.ModalSelfServiceConfirmDialog.getCloseHandler(modalSelector);
+        });
+
+        $('btn-close').on('click', function () {
+            foodcoopshop.ModalSelfServiceConfirmDialog.getCloseHandler(modalSelector);
+        }); 
     },
 
     getSuccessHandler : function() {
@@ -54,6 +62,10 @@ foodcoopshop.ModalSelfServiceConfirmDialog = {
 
     getOpenHandler : function(modalSelector) {
         new bootstrap.Modal(document.getElementById(modalSelector.replace(/#/, ''))).show();
+    },
+
+    getCloseHandler : function(modalSelector) {
+        foodcoopshop.SelfService.setFocusToSearchInputField();
     },
 
 };

--- a/webroot/js/modal/modal-self-service-confirm-dialog.js
+++ b/webroot/js/modal/modal-self-service-confirm-dialog.js
@@ -42,15 +42,15 @@ foodcoopshop.ModalSelfServiceConfirmDialog = {
             foodcoopshop.ModalSelfServiceConfirmDialog.getOpenHandler(modalSelector);
         });
 
-        $('button.btn-success.no-auto-bind').on('click', function () {
+        $(modalSelector + ' button.btn-success.no-auto-bind').on('click', function () {
             foodcoopshop.ModalSelfServicePaymenttypeDetailsDialog.getOpenHandler('#self-service-confirm-dialog-paymenttype-details', $(this).text(), $(this).attr('value'));
-        });  
+        });
 
-        $('btn-outline-light').on('click', function () {
+        $(modalSelector + ' button.btn-outline-light').on('click', function () {
             foodcoopshop.ModalSelfServiceConfirmDialog.getCloseHandler(modalSelector);
         });
 
-        $('btn-close').on('click', function () {
+        $(modalSelector + ' button.btn-close').on('click', function () {
             foodcoopshop.ModalSelfServiceConfirmDialog.getCloseHandler(modalSelector);
         }); 
     },


### PR DESCRIPTION
setFocusToSearchInputField when closing modal-self-service-confirm-dialog or modal-self-service-confirm-dialog-paymenttypes-details