### PR TITLE
PaymenttypeButtonsOnlyForNotSelfServiceUsers

### DIFF
--- a/templates/element/selfService/initCartFinishDialog.php
+++ b/templates/element/selfService/initCartFinishDialog.php
@@ -27,7 +27,7 @@ $html = '';
 $dialogButtons = [];
 $selfServicePaymentTypes = Configure::read('app.selfServicePaymentTypes');
 
-if (empty($selfServicePaymentTypes)) {
+if (empty($selfServicePaymentTypes) || !$identity->isSelfServiceCustomer()) {
     $title = __('Confirm_self_service_purchase_dialog') .'?';
     $html = '<p>' . __('Confirm_self_service_purchase') . '</p>';
     $dialogButtons[] = [

--- a/templates/element/selfService/paymentType.php
+++ b/templates/element/selfService/paymentType.php
@@ -31,17 +31,23 @@ if (!Configure::read('app.selfServiceEasyModeEnabled')) {
         $paymentTypeAsString =  __('Cash');
     }
 } else {
-    $selfServicePaymentTypes = Configure::read('app.selfServicePaymentTypes');
-    if(!empty($selfServicePaymentTypes)) {
-        $countSelfServicePaymentTypes = count($selfServicePaymentTypes);
-        $i = 1;
-        foreach($selfServicePaymentTypes as $selfServicePaymentType) {
-            $paymentTypeAsString .= $selfServicePaymentType['payment_type'];
-            if ($countSelfServicePaymentTypes > 1 && !($i == $countSelfServicePaymentTypes)){
-                $paymentTypeAsString .= ', ';
-            }
-            $i++;
-        }
+    if($identity->isSelfServiceCustomer()){
+      $selfServicePaymentTypes = Configure::read('app.selfServicePaymentTypes');
+      if(!empty($selfServicePaymentTypes)) {
+          $countSelfServicePaymentTypes = count($selfServicePaymentTypes);
+          $i = 1;
+          foreach($selfServicePaymentTypes as $selfServicePaymentType) {
+              $paymentTypeAsString .= $selfServicePaymentType['payment_type'];
+              if ($countSelfServicePaymentTypes > 1 && !($i == $countSelfServicePaymentTypes)){
+                  $paymentTypeAsString .= ', ';
+              }
+              $i++;
+          }
+      } else{
+        $paymentTypeAsString =  __('Cash');
+      }
+    }else{
+      $paymentTypeAsString =  __('Credit');
     }
 }
 

--- a/templates/element/selfService/paymentType.php
+++ b/templates/element/selfService/paymentType.php
@@ -24,30 +24,26 @@ if (!Configure::read('appDb.FCS_SEND_INVOICES_TO_CUSTOMERS')) {
 }
 
 $paymentTypeAsString = '';
+
+if (Configure::read('app.selfServiceEasyModeEnabled')) {
+
+    $paymentTypeAsString =  __('Credit');
+
+    if ($identity->isSelfServiceCustomer()) {
+        $paymentTypes = [__('Cash')];
+        $selfServicePaymentTypes = Configure::read('app.selfServicePaymentTypes');
+        if(!empty($selfServicePaymentTypes)) {
+            $paymentTypes  = array_column($selfServicePaymentTypes, 'payment_type');
+        }
+        $paymentTypeAsString = implode(', ', $paymentTypes);
+    }
+}
+
 if (!Configure::read('app.selfServiceEasyModeEnabled')) {
     $cartsTable = FactoryLocator::get('Table')->get('Carts');
     $paymentTypeAsString = __('Credit');
     if ($paymentType == Cart::SELF_SERVICE_PAYMENT_TYPE_CASH) {
         $paymentTypeAsString =  __('Cash');
-    }
-} else {
-    if($identity->isSelfServiceCustomer()){
-      $selfServicePaymentTypes = Configure::read('app.selfServicePaymentTypes');
-      if(!empty($selfServicePaymentTypes)) {
-          $countSelfServicePaymentTypes = count($selfServicePaymentTypes);
-          $i = 1;
-          foreach($selfServicePaymentTypes as $selfServicePaymentType) {
-              $paymentTypeAsString .= $selfServicePaymentType['payment_type'];
-              if ($countSelfServicePaymentTypes > 1 && !($i == $countSelfServicePaymentTypes)){
-                  $paymentTypeAsString .= ', ';
-              }
-              $i++;
-          }
-      } else{
-        $paymentTypeAsString =  __('Cash');
-      }
-    }else{
-      $paymentTypeAsString =  __('Credit');
     }
 }
 


### PR DESCRIPTION
Wenn Easymode = true und Paymenttypes konfiguriert waren wurden diese auch für Nicht-Selbstbedienungsbenutzer im SB-Dialog angezeigt. => NOK
SOLL: Die konfigurierten Paymenttyps sollen im Easymode nur für SB-Benutzer angezeigt werden. Für Kunden, welche sich mit Mitgliedskarte anmelden soll immer Guthaben angezeigt werden, das war aktuell nicht mehr so (PS: Einkäufe wurden aber richtig mit Guthaben verbucht nur die Anzeige passte nicht)