### PR TITLE
GLS Bank seems to have adjusted their CSV Collumns

### DIFF
--- a/src/Services/Csv/Reader/Banking/GlsBankBankingReaderService.php
+++ b/src/Services/Csv/Reader/Banking/GlsBankBankingReaderService.php
@@ -31,7 +31,7 @@ class GlsBankBankingReaderService extends BankingReaderService {
 
         $result = false;
 
-        if (count($record) == 18 &&
+        if ((count($record) == 18 || count($record) == 19) &&
             strlen($record['Valutadatum']) == 10 &&
             $record['Waehrung'] == 'EUR' &&
             is_numeric(Configure::read('app.numberHelper')->getStringAsFloat($record['Betrag'])) &&


### PR DESCRIPTION
I don't know since when but GLS Bank seems to have changed their CSV export format. We're now counting 18 entries per record and not 19. I've checked with our foodcoop account and my private one and both have 18 entries so I've adjusted the script slightly to make i work again.