### PR TITLE
Update 20250905082316_DatabaseImprovements.php

### DIFF
--- a/config/Migrations/20250905082316_DatabaseImprovements.php
+++ b/config/Migrations/20250905082316_DatabaseImprovements.php
@@ -16,7 +16,7 @@ class DatabaseImprovements extends BaseMigration
             'fcs_order_detail_purchase_prices'
         ];
         foreach ($tables as $table) {
-            $sql = "ALTER TABLE $table CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;";
+            $sql = "ALTER TABLE $table CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;";
             $this->execute($sql);
         }
 


### PR DESCRIPTION
for MariaDB: use collation utf8mb4_unicode_ci instead of utf8mb4_0900_ai_ci

