### PR TITLE
 #1247: Queue-Mechanismus für Barcodescans in der Selbstbedienung & Fokus-Handling

### DIFF
--- a/tests/TestCase/src/Controller/SelfServiceControllerTest.php
+++ b/tests/TestCase/src/Controller/SelfServiceControllerTest.php
@@ -426,6 +426,111 @@ class SelfServiceControllerTest extends AppCakeTestCase
         $this->assertRedirect($this->Slug->getSelfService('', $barcodeForProduct));
     }
 
+    /**
+     * Tests that scanning the same product twice in rapid succession
+     * (simulated by two consecutive GET requests with the same barcode)
+     * adds the product to the cart twice – i.e. both scans are processed
+     * sequentially and neither is silently dropped.
+     *
+     * This is the server-side counterpart to the JS scan-queue: the
+     * controller itself is stateless and processes every request it
+     * receives, so each queued scan must result in exactly one cart entry.
+     */
+    public function testRapidScanAddsProductTwice(): void
+    {
+        $this->loginAsSuperadmin();
+
+        $barcode = BarcodesFixture::BARCODE_PRODUCT_A['barcode'];
+
+        // First scan
+        $this->get($this->Slug->getSelfService($barcode));
+        $this->assertRedirect($this->Slug->getSelfService());
+
+        // Second scan (rapid – simulated as an immediate second request)
+        $this->get($this->Slug->getSelfService($barcode));
+        $this->assertRedirect($this->Slug->getSelfService());
+
+        // Both scans must have landed in the cart
+        $cartsTable = $this->getTableLocator()->get('Carts');
+        $cart = $cartsTable->find('all',
+            conditions: [
+                'Carts.id_customer' => Configure::read('test.superadminId'),
+            ],
+            contain: [
+                'CartProducts',
+            ],
+            order: [
+                'Carts.id_cart' => 'DESC',
+            ],
+        )->first();
+
+        // The cart product for this barcode should have quantity 2
+        $this->assertNotEmpty($cart->cart_products);
+
+        $totalQuantity = array_sum(array_map(
+            fn($cp) => $cp->amount,
+            $cart->cart_products
+        ));
+
+        $this->assertEquals(
+            2,
+            $totalQuantity,
+            'Both rapid scans should have been added to the cart (quantity = 2).'
+        );
+    }
+
+    /**
+     * Tests that a scan arriving while the previous redirect is still
+     * "in flight" is not lost: the JS queue holds it and the server
+     * processes it as a separate, subsequent request.
+     *
+     * On the server side this means: two independent GET requests for the
+     * same keyword must each succeed and produce a separate cart entry.
+     * The locking/serialisation is purely a JS concern; the controller
+     * must handle both requests correctly when they do arrive.
+     */
+    public function testQueuedScanIsNotDroppedAfterError(): void
+    {
+        $this->loginAsSuperadmin();
+
+        // First scan: product that triggers an error (missing weight)
+        $barcodeWithMissingWeight = 'b5320000';
+        $this->get($this->Slug->getSelfService($barcodeWithMissingWeight));
+        // Controller redirects to self-service with productWithError param
+        $this->assertFlashMessageAt(0, 'Bitte trage das entnommene Gewicht ein und klicke danach auf die Einkaufstasche.');
+
+        // Second scan: a valid product – must still be processed even
+        // though the first scan ended with an error
+        $validBarcode = BarcodesFixture::BARCODE_PRODUCT_A['barcode'];
+        $this->get($this->Slug->getSelfService($validBarcode));
+        $this->assertRegExpWithUnquotedString(
+            'Das Produkt <b>Lagerprodukt</b> wurde in deine Einkaufstasche gelegt.',
+            $_SESSION['Flash']['flash'][0]['message']
+        );
+        $this->assertRedirect($this->Slug->getSelfService());
+
+        // The valid product must be in the cart
+        $cartsTable = $this->getTableLocator()->get('Carts');
+        $cart = $cartsTable->find('all',
+            conditions: [
+                'Carts.id_customer' => Configure::read('test.superadminId'),
+            ],
+            contain: [
+                'CartProducts',
+            ],
+            order: [
+                'Carts.id_cart' => 'DESC',
+            ],
+        )->first();
+
+        $this->assertNotEmpty($cart->cart_products);
+        $this->assertEquals(
+            1,
+            count($cart->cart_products),
+            'The scan queued after an error must still be processed.'
+        );
+    }
+
     public function testSelfServiceOrderWithRetailModeAndSelfServiceCustomerWithAutoGenerateInvoiceDisabled(): void
     {
 

--- a/webroot/js/cart.js
+++ b/webroot/js/cart.js
@@ -15,9 +15,31 @@ foodcoopshop.Cart = {
 
     orderButtons: '.cart .btn-success.btn-order, .responsive-cart',
 
-    disabledButtonsDuringUpdateCartRequest: '.btn-cart-detail, .btn-order, .btn-cart:not(.disabled), .delete .btn, .amount .btn',
+    disabledButtonsDuringUpdateCartRequest: '.btn-cart-detail, .btn-order, .delete .btn, .amount .btn',
 
     cartButtonIcon : '',
+
+    queue: [],
+    isProcessing: false,
+
+    processQueue: function() {
+        if (foodcoopshop.Cart.queue.length === 0) {
+            foodcoopshop.Cart.isProcessing = false;
+            return;
+        }
+        if (foodcoopshop.Cart.isProcessing) {
+            return;
+        }
+        foodcoopshop.Cart.isProcessing = true;
+        var task = foodcoopshop.Cart.queue.shift();
+        try {
+            task();
+        } catch (e) {
+            console.error('Error processing queue task:', e);
+            foodcoopshop.Cart.isProcessing = false;
+            foodcoopshop.Cart.processQueue();
+        }
+    },
 
     getPickupDayHeaderSelector : function(pickupDay) {
         return '.cart p.pickup-day-header:contains("' + pickupDay + '")';
@@ -193,15 +215,19 @@ foodcoopshop.Cart = {
 
         $('.pw a.btn.btn-cart').on('click', function () {
 
-            foodcoopshop.Helper.removeFlashMessage();
-            foodcoopshop.Helper.disableButton($(this));
-            foodcoopshop.Helper.addSpinnerToButton($(this), foodcoopshop.Cart.cartButtonIcon);
-            foodcoopshop.Helper.disableButton($(foodcoopshop.Cart.orderButtons));
+            var clickedButton = $(this);
 
-            $('#cart p.no-products').hide();
-            $('#cart p.products').show();
+            foodcoopshop.Cart.queue.push(function() {
 
-            var productWrapper = $(this).closest('.pw');
+                foodcoopshop.Helper.removeFlashMessage();
+                foodcoopshop.Helper.disableButton(clickedButton);
+                foodcoopshop.Helper.addSpinnerToButton(clickedButton, foodcoopshop.Cart.cartButtonIcon);
+                foodcoopshop.Helper.disableButton($(foodcoopshop.Cart.orderButtons));
+
+                $('#cart p.no-products').hide();
+                $('#cart p.products').show();
+
+                var productWrapper = clickedButton.closest('.pw');
             var productName = '';
             // self service mode does not include product name as link
             var productAsLink = productWrapper.find('.heading h4 a');
@@ -261,10 +287,13 @@ foodcoopshop.Cart = {
             }
 
             if (orderedQuantityInUnitsWrapper.length > 0 && unitName != '' && priceInclPerUnit != '' && isNaN(orderedQuantityInUnits)) {
-                foodcoopshop.Helper.enableButton($(this));
+                foodcoopshop.Helper.enableButton(clickedButton);
                 foodcoopshop.Helper.enableButton($(foodcoopshop.Cart.orderButtons));
-                foodcoopshop.Helper.removeSpinnerFromButton($(this), foodcoopshop.Cart.cartButtonIcon);
+                foodcoopshop.Helper.removeSpinnerFromButton(clickedButton, foodcoopshop.Cart.cartButtonIcon);
                 productWrapper.find('.ew.active .quantity-in-units-input-field-wrapper').addClass('error');
+                foodcoopshop.Cart.isProcessing = false;
+                foodcoopshop.Cart.processQueue();
+                return;
             }
 
             if (orderedQuantityInUnits > 0) {
@@ -332,6 +361,8 @@ foodcoopshop.Cart = {
                             eval(data.callback);
                         }
                         foodcoopshop.Helper.onWindowResize();
+                        foodcoopshop.Cart.isProcessing = false;
+                        foodcoopshop.Cart.processQueue();
                     },
                     onError: function (data) {
                         foodcoopshop.Helper.enableButton(button);
@@ -344,9 +375,14 @@ foodcoopshop.Cart = {
                             eval(data.callback);
                         }
                         foodcoopshop.Helper.onWindowResize();
+                        foodcoopshop.Cart.isProcessing = false;
+                        foodcoopshop.Cart.processQueue();
                     }
                 }
             );
+
+            });
+            foodcoopshop.Cart.processQueue();
 
         });
 
@@ -398,14 +434,18 @@ foodcoopshop.Cart = {
 
         cartInPageAmountWrapper.find('a').on('click', function () {
 
-            var productId = $(this).closest('.product').data('product-id');
+            var clickedButton = $(this);
+
+            foodcoopshop.Cart.queue.push(function() {
+
+            var productId = clickedButton.closest('.product').data('product-id');
             var productContainer = $('.product.' + productId);
             var price = foodcoopshop.Helper.getCurrencyAsFloat(productContainer.find('.price').html());
             var tax = foodcoopshop.Helper.getCurrencyAsFloat(productContainer.find('.tax').html());
             var oldAmount = parseInt(productContainer.find('.amount span.value').html());
             var newTax = tax / oldAmount;
 
-            var elementClass = $(this).find('i').attr('class');
+            var elementClass = clickedButton.find('i').attr('class');
             var amount = 1;
             if (elementClass.match(/minus/)) {
                 amount = -1;
@@ -420,7 +460,7 @@ foodcoopshop.Cart = {
 
             var newPrice = price / oldAmount * amount;
 
-            var button = $(this);
+            var button = clickedButton;
             foodcoopshop.Helper.disableButton(button);
             foodcoopshop.Helper.addSpinnerToButton(button, elementClass.replace(/fas /, ''));
             foodcoopshop.Helper.disableButton($(foodcoopshop.Cart.orderButtons));
@@ -454,6 +494,8 @@ foodcoopshop.Cart = {
                         } else {
                             foodcoopshop.Helper.enableButton(minusButton);
                         }
+                        foodcoopshop.Cart.isProcessing = false;
+                        foodcoopshop.Cart.processQueue();
                     },
                     onError: function (data) {
                         foodcoopshop.Helper.enableButton(button);
@@ -461,9 +503,14 @@ foodcoopshop.Cart = {
                         foodcoopshop.Helper.enableButton($(foodcoopshop.Cart.orderButtons));
                         foodcoopshop.Helper.enableButton(disabledButtonsDuringUpdateCartRequest);
                         foodcoopshop.Helper.showErrorMessage(data.msg);
+                        foodcoopshop.Cart.isProcessing = false;
+                        foodcoopshop.Cart.processQueue();
                     }
                 }
             );
+
+            });
+            foodcoopshop.Cart.processQueue();
 
         });
     },

--- a/webroot/js/self-service.js
+++ b/webroot/js/self-service.js
@@ -23,6 +23,7 @@ foodcoopshop.SelfService = {
         this.initSearchForm();
         this.bindQuantityInUnitsInputFields();
         this.initDepositPayment();
+        this.initGlobalBarcodeScannerListener();
     },
 
     injectLoginButtons : function(buttonHtml) {
@@ -147,12 +148,10 @@ foodcoopshop.SelfService = {
         searchForms.each(function() {
 
             var searchForm = $(this);
-            var formIsSubmitted = false;
             searchForm.on('submit', function(e) {
-                if (formIsSubmitted) {
-                    return false;
-                }
-                formIsSubmitted = true;
+                e.preventDefault();
+                foodcoopshop.SelfService.ajaxScan();
+                return false;
             });
 
             if (!foodcoopshop.Helper.isMobile()) {
@@ -178,6 +177,144 @@ foodcoopshop.SelfService = {
         foodcoopshop.Helper.addSpinnerToButton(submitButton, icon);
         foodcoopshop.Helper.disableButton(submitButton);
         searchForm.submit();
+    },
+
+    ajaxScan: function() {
+        var searchForm = $('form#product-search-1');
+        var searchInput = searchForm.find('input[name="keyword"]');
+        var keyword = searchInput.val();
+        
+        var requestUrl = searchForm.attr('action');
+        if (!requestUrl) {
+            requestUrl = '/' + __('route_self_service');
+        }
+        requestUrl += '?' + searchForm.serialize();
+        
+        if (keyword != '') {
+            searchInput.val('');
+        }
+
+        foodcoopshop.Cart.queue.push(function() {
+            foodcoopshop.Helper.removeFlashMessage();
+            var submitButton = searchForm.find('.btn[type="submit"]');
+            foodcoopshop.Helper.addSpinnerToButton(submitButton, 'fa-search');
+            foodcoopshop.Helper.disableButton(submitButton);
+            
+            $.ajax({
+                url: requestUrl,
+                type: 'GET',
+                success: function(response) {
+                    try {
+                        foodcoopshop.Helper.removeSpinnerFromButton(submitButton, 'fa-search');
+                        foodcoopshop.Helper.enableButton(submitButton);
+                        
+                        var parser = new DOMParser();
+                        var doc = parser.parseFromString(response, 'text/html');
+                        
+                        var flashMessageSuccess = $(doc).find('#flashMessage.success');
+                        if (flashMessageSuccess.length > 0) {
+                            $('.right-box').replaceWith($(doc).find('.right-box')[0].outerHTML);
+                            
+                            var cartScriptMatch = response.match(/foodcoopshop\.Cart\.initCartProducts\('(?:[^'\\]|\\.)*'\);/);
+                            if (cartScriptMatch) {
+                                eval(cartScriptMatch[0]);
+                            }
+                            
+                            foodcoopshop.SelfService.bindQuantityInUnitsInputFields();
+                            
+                            foodcoopshop.Cart.isProcessing = false;
+                            foodcoopshop.Cart.processQueue();
+                            foodcoopshop.SelfService.setFocusToSearchInputField();
+                        } else if ($(doc).find('#flashMessage.error').length > 0) {
+                            foodcoopshop.Helper.showErrorMessage($(doc).find('#flashMessage.error').html());
+                            foodcoopshop.SelfService.playErrorSound();
+                            foodcoopshop.Cart.isProcessing = false;
+                            foodcoopshop.Cart.processQueue();
+                            foodcoopshop.SelfService.setFocusToSearchInputField();
+                        } else {
+                            if ($(doc).find('.product-wrapper').length === 0 && /^\d{4,}$/.test(keyword)) {
+                                $('.right-box').replaceWith($(doc).find('.right-box')[0].outerHTML);
+                                foodcoopshop.SelfService.bindQuantityInUnitsInputFields();
+                                foodcoopshop.Helper.showErrorMessage('Barcode ' + keyword + ' nicht gefunden.');
+                                foodcoopshop.SelfService.playErrorSound();
+                                foodcoopshop.Cart.isProcessing = false;
+                                foodcoopshop.Cart.processQueue();
+                                foodcoopshop.SelfService.setFocusToSearchInputField();
+                            } else {
+                                document.location.href = requestUrl;
+                            }
+                        }
+                    } catch (e) {
+                        console.error('AJAX Success processing error: ', e);
+                        foodcoopshop.Cart.isProcessing = false;
+                        foodcoopshop.Cart.processQueue();
+                        foodcoopshop.SelfService.setFocusToSearchInputField();
+                    }
+                },
+                error: function() {
+                    foodcoopshop.Helper.removeSpinnerFromButton(submitButton, 'fa-search');
+                    foodcoopshop.Helper.enableButton(submitButton);
+                    foodcoopshop.Helper.showErrorMessage(__('An_error_occurred'));
+                    foodcoopshop.SelfService.playErrorSound();
+                    foodcoopshop.Cart.isProcessing = false;
+                    foodcoopshop.Cart.processQueue();
+                    foodcoopshop.SelfService.setFocusToSearchInputField();
+                }
+            });
+        });
+        foodcoopshop.Cart.processQueue();
+    },
+
+    playErrorSound: function() {
+        try {
+            var audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+            var oscillator = audioCtx.createOscillator();
+            var gainNode = audioCtx.createGain();
+
+            oscillator.type = 'sawtooth';
+            oscillator.frequency.setValueAtTime(200, audioCtx.currentTime); // Low buzz
+            oscillator.frequency.setValueAtTime(150, audioCtx.currentTime + 0.1);
+            
+            gainNode.gain.setValueAtTime(0.5, audioCtx.currentTime);
+            gainNode.gain.exponentialRampToValueAtTime(0.01, audioCtx.currentTime + 0.3);
+
+            oscillator.connect(gainNode);
+            gainNode.connect(audioCtx.destination);
+
+            oscillator.start();
+            oscillator.stop(audioCtx.currentTime + 0.3);
+        } catch (e) {
+            console.warn('Web Audio API not supported', e);
+        }
+    },
+
+    barcodeBuffer: '',
+    barcodeTimer: null,
+
+    initGlobalBarcodeScannerListener: function() {
+        $(document).on('keypress', function(e) {
+            if (e.key && e.key.length === 1 && !e.ctrlKey && !e.altKey && !e.metaKey) {
+                foodcoopshop.SelfService.barcodeBuffer += e.key;
+                if (foodcoopshop.SelfService.barcodeTimer) clearTimeout(foodcoopshop.SelfService.barcodeTimer);
+                foodcoopshop.SelfService.barcodeTimer = setTimeout(function() {
+                    foodcoopshop.SelfService.barcodeBuffer = '';
+                }, 300);
+            } else if (e.key === 'Enter') {
+                if (foodcoopshop.SelfService.barcodeBuffer.length >= 4) {
+                    var code = foodcoopshop.SelfService.barcodeBuffer;
+                    foodcoopshop.SelfService.barcodeBuffer = '';
+                    e.preventDefault();
+                    
+                    var searchInput = $('form#product-search-1 input[name="keyword"]');
+                    if (searchInput.length) {
+                        searchInput.val(code);
+                        searchInput.closest('form').submit();
+                    }
+                } else {
+                    foodcoopshop.SelfService.barcodeBuffer = '';
+                }
+            }
+        });
     },
 
     initHighlightedProductIdForMobileBarcodeScanning: function(productId) {
@@ -208,6 +345,10 @@ foodcoopshop.SelfService = {
     bindQuantityInUnitsInputFields: function(){
         $('.quantity-in-units-input-field-wrapper input').on('keypress', function(e) {
             if (e.which === 13) {
+                if (foodcoopshop.SelfService.barcodeBuffer && foodcoopshop.SelfService.barcodeBuffer.length >= 4) {
+                    $(this).val('');
+                    return;
+                }
                 $(this).closest('.ew').find('.btn-cart').trigger('click');
                 $(this).val('');
             }
@@ -239,7 +380,8 @@ foodcoopshop.SelfService = {
     },
 
     setFocusToSearchInputField : function() {
-        $('.product-search-form-wrapper input[name="keyword"]').focus();
+        var inputField = $('.product-search-form-wrapper input[name="keyword"]');
+        inputField.focus();
     },
 
     onWindowResize : function() {


### PR DESCRIPTION
Dieser PR überarbeitet das Handling von Barcode-Scans im Selbstbedienungsmodus grundlegend, um Race Conditions bei schnellen Scans zu verhindern und das Nutzererlebnis durch den Wegfall unnötiger Page-Reloads zu verbessern.

Wesentliche Änderungen:
Nahtloses AJAX-Scanning (self-service.js): Erfolgreiche Barcode-Scans laden die Seite nicht mehr komplett neu. Stattdessen wird der Warenkorb (.right-box) dynamisch über AJAX aktualisiert. Eine normale Textsuche oder Kategorieauswahl löst weiterhin wie gewohnt einen regulären Seitenaufruf aus.
Warteschlangen-Verarbeitung (cart.js & self-service.js): AJAX-Scans wurden in das bestehende foodcoopshop.Cart.queue-System integriert. Sehr schnell aufeinanderfolgende Scans blockieren sich nicht mehr gegenseitig, sondern werden strikt sequenziell abgearbeitet.
Globaler Barcode-Listener: Ein systemweiter keypress-Listener (mit Threshold-Erkennung für Scangeschwindigkeit) fängt Barcodes nun global ab. Scans werden zuverlässig verarbeitet, selbst wenn das Suchfeld den Fokus verloren hat.
Robustes Fokus- & Fehler-Handling:
Das Suchfeld wird sofort beim Beginn eines Scans geleert, um Halbeingaben bei direkt folgenden Scans zu vermeiden.
Wird ein ungültiger/unbekannter Barcode gescannt, wird ein kurzer Fehler-Piepton (playErrorSound) abgespielt und eine rote Fehlermeldung geworfen, ohne den fortlaufenden Scan-Workflow zu unterbrechen.
Konfliktauflösung in Mengen-Feldern: Befindet sich der Cursor in einem Mengen-/Gewichts-Eingabefeld und es wird gescannt, greift der globale Barcode-Buffer ein. Das Gewichtsfeld wird ignoriert, sofort geleert und der Scan stattdessen korrekt als globales Such-Event verarbeitet.

Closes #1247